### PR TITLE
Set 'eq=False' in VersionRange and VersionConstraint for the __eq__ method to work

### DIFF
--- a/src/univers/version_constraint.py
+++ b/src/univers/version_constraint.py
@@ -53,7 +53,7 @@ COMPARATORS = {
 
 
 @total_ordering
-@attr.s(frozen=True, repr=True, str=False, order=False, eq=True, hash=True)
+@attr.s(frozen=True, repr=True, str=False, order=False, eq=False, hash=True)
 class VersionConstraint:
     """
     Represent a single constraint composed of a comparator and a version.

--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -39,7 +39,7 @@ INVERTED_COMPARATORS = {
 }
 
 
-@attr.s(frozen=True, order=False, eq=True, hash=True)
+@attr.s(frozen=True, order=False, eq=False, hash=True)
 class VersionRange:
     """
     Base version range class. Subclasses must provide implement.


### PR DESCRIPTION
Fix #43 

Added 'eq=False' to the attr parameter in VersionRange and VersionConstraint so that the __eq__ method could take effect.