### PR TITLE
Add support for Openstack Advisories

### DIFF
--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -790,23 +790,56 @@ class PypiVersionRange(VersionRange):
 
         >>> str(PypiVersionRange.from_ossa_native("<20.2.1, >=21.0.0 <21.2.1, ==22.0.0"))
         'vers:pypi/<20.2.1|>=21.0.0|<21.2.1|22.0.0'
+
+        >>> str(PypiVersionRange.from_ossa_native(">=1.15.0<1.15.2, 1.16.0"))
+        'vers:pypi/>=1.15.0|<1.15.2|1.16.0'
         """
 
         # Normalize "and" keyword to comma
         # "<=5.0.3, >=6.0.0 <=6.1.0 and ==7.0.0" -> "<=5.0.3, >=6.0.0 <=6.1.0, ==7.0.0"
         string = string.replace(" and ", ",")
 
-        # Remove spaces around operators
-        # "<=5.0.3, >=6.0.0 <=6.1.0, ==7.0.0" -> "<=5.0.3,>=6.0.0<=6.1.0,==7.0.0"
-        string = re.sub(r"\s+([<>=!]+)", r"\1", string)
-        string = re.sub(r"([<>=!]+)\s+", r"\1", string)
+        # Split on commas then whitespace to get individual tokens
+        # "<=5.0.3 >=6.0.0 " -> ["<=5.0.3", ">=6.0.0"]
+        raw_tokens = [token for chunk in string.split(",") for token in chunk.split()]
 
-        # Insert comma between consecutive constraints
-        # "<=5.0.3,>=6.0.0<=6.1.0,==7.0.0" -> "<=5.0.3,>=6.0.0,<=6.1.0,==7.0.0"
-        string = re.sub(r"(\d)([<>=!])", r"\1,\2", string)
+        if not raw_tokens:
+            raise InvalidVersionRange(f"Empty or invalid OSSA version string: {string!r}")
+
+        # Merge tokens where the operator and version are separated by a space
+        # ["<=", "5.0.3", ">=", "6.0.0"] -> ["<=5.0.3", ">=6.0.0"]
+        raw_iter = iter(raw_tokens)
+        fused_tokens = []
+        for current in raw_iter:
+            is_bare_operator = all(c in "<>=!" for c in current)
+            if is_bare_operator:
+                fused_tokens.append(current + next(raw_iter))
+            else:
+                fused_tokens.append(current)
+
+        # Split tokens that contain multiple concatenated constraints without separator
+        # ">=1.15.0<1.15.2" -> [">=1.15.0", "<1.15.2"]
+        parts = []
+        for token in fused_tokens:
+
+            token_len = len(token)
+            pos = 0
+            while pos < token_len and token[pos] in "<>=!":
+                pos += 1
+
+            segment_start = 0
+            while pos < token_len:
+                if token[pos] in "<>=!":
+                    parts.append(token[segment_start:pos])
+                    segment_start = pos
+                    while pos < token_len and token[pos] in "<>=!":
+                        pos += 1
+                else:
+                    pos += 1
+            parts.append(token[segment_start:])
 
         constraints = []
-        for part in string.split(","):
+        for part in parts:
 
             # Default to exact match for bare version numbers
             # "1.16.0" -> "=1.16.0"

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -281,6 +281,48 @@ def test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges(range, w
         assert expected == str(PypiVersionRange.from_native(range))
 
 
+@pytest.mark.parametrize(
+    "string, expected",
+    [
+        (  # OSSA-2016-013
+            "<=5.0.3, >=6.0.0 <=6.1.0 and ==7.0.0",
+            "vers:pypi/<=5.0.3|>=6.0.0|<=6.1.0|7.0.0",
+        ),
+        (  # OSSA-2017-005
+            "<=14.0.10, >=15.0.0 <=15.0.8, >=16.0.0 <=16.0.3",
+            "vers:pypi/<=14.0.10|>=15.0.0|<=15.0.8|>=16.0.0|<=16.0.3",
+        ),
+        (  # OSSA-2019-003
+            "<17.0.12, >=18.0.0 <18.2.2, >=19.0.0 <19.0.2",
+            "vers:pypi/<17.0.12|>=18.0.0|<18.2.2|>=19.0.0|<19.0.2",
+        ),
+        (  # OSSA-2020-006
+            "<19.3.1, >=20.0.0 <20.3.1, ==21.0.0",
+            "vers:pypi/<19.3.1|>=20.0.0|<20.3.1|21.0.0",
+        ),
+        (  # OSSA-2026-001
+            ">=10.5.0 <10.7.2, >=10.8.0 <10.9.1, >=10.10.0 <10.12.1",
+            "vers:pypi/>=10.5.0|<10.7.2|>=10.8.0|<10.9.1|>=10.10.0|<10.12.1",
+        ),
+        (  # OSSA-2021-001
+            "<16.3.3, >=17.0.0 <17.1.3, =18.0.0",
+            "vers:pypi/<16.3.3|>=17.0.0|<17.1.3|18.0.0",
+        ),
+        (  # empty string should raise InvalidVersionRange
+            "",
+            "InvalidVersionRange",
+        ),
+    ],
+)
+def test_PypiVersionRange_from_ossa_native(string, expected):
+    if expected == "InvalidVersionRange":
+        with pytest.raises(InvalidVersionRange):
+            PypiVersionRange.from_ossa_native(string)
+    else:
+        result = PypiVersionRange.from_ossa_native(string)
+        assert expected == str(result)
+
+
 def test_invert():
     vers_with_equal_operator = VersionRange.from_string("vers:gem/1.0")
     assert str(vers_with_equal_operator.invert()) == "vers:gem/!=1.0"


### PR DESCRIPTION
Resolves:
- https://github.com/aboutcode-org/univers/issues/183

Added `from_ossa_native` function and its corresponding unit test.

Unit test logs:

``` python
collected 4661 items / 4645 deselected / 16 selected                                                 

tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[ ~= 0.9-False-Unsupported PyPI version constraint operator] PASSED [  6%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[~= 1.3-False-Unsupported PyPI version constraint operator] PASSED [ 12%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[ >= 1.0-True-vers:pypi/>=1.0] PASSED [ 18%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[ != 1.3.4.*-False-Unsupported PyPI version] PASSED [ 25%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[< 2.0-True-vers:pypi/<2.0] PASSED [ 31%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[~= 1.3.4.*-False-] PASSED [ 37%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[==1. *-False-Unsupported PyPI version] PASSED [ 43%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[==1.3.4 ) (-False-Unsupported character] PASSED [ 50%]
tests/test_version_range.py::test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges[===1.0-False-Unsupported PyPI version] PASSED [ 56%]
tests/test_version_range.py::test_PypiVersionRange_from_ossa_native[<=5.0.3, >=6.0.0 <=6.1.0 and ==7.0.0-vers:pypi/<=5.0.3|>=6.0.0|<=6.1.0|7.0.0] PASSED [ 62%]
tests/test_version_range.py::test_PypiVersionRange_from_ossa_native[<=14.0.10, >=15.0.0 <=15.0.8, >=16.0.0 <=16.0.3-vers:pypi/<=14.0.10|>=15.0.0|<=15.0.8|>=16.0.0|<=16.0.3] PASSED [ 68%]
tests/test_version_range.py::test_PypiVersionRange_from_ossa_native[<17.0.12, >=18.0.0 <18.2.2, >=19.0.0 <19.0.2-vers:pypi/<17.0.12|>=18.0.0|<18.2.2|>=19.0.0|<19.0.2] PASSED [ 75%]
tests/test_version_range.py::test_PypiVersionRange_from_ossa_native[<19.3.1, >=20.0.0 <20.3.1, ==21.0.0-vers:pypi/<19.3.1|>=20.0.0|<20.3.1|21.0.0] PASSED [ 81%]
tests/test_version_range.py::test_PypiVersionRange_from_ossa_native[>=10.5.0 <10.7.2, >=10.8.0 <10.9.1, >=10.10.0 <10.12.1-vers:pypi/>=10.5.0|<10.7.2|>=10.8.0|<10.9.1|>=10.10.0|<10.12.1] PASSED [ 87%]
tests/test_version_range.py::test_PypiVersionRange_from_ossa_native[<16.3.3, >=17.0.0 <17.1.3, =18.0.0-vers:pypi/<16.3.3|>=17.0.0|<17.1.3|18.0.0] PASSED [ 93%]
tests/test_version_range.py::test_PypiVersionRange_from_ossa_native[-InvalidVersionRange] PASSED [100%]

========================== 16 passed, 4645 deselected, 54 warnings in 0.20s ==========================
```
Took some inspiration from `from_gitlab_native` function.