### PR TITLE
fix: return None when from_versions is called with empty constraints

### DIFF
--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -183,7 +183,7 @@ class VersionRange:
             version_obj = cls.version_class(version)
             constraint = VersionConstraint(comparator="=", version=version_obj)
             constraints.append(constraint)
-        return cls(constraints=constraints)
+        return cls(constraints=constraints) if constraints else None
 
     def is_star(self):
         return len(self.constraints) == 1 and self.constraints[0].is_star()

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -220,6 +220,13 @@ def test_AlpineLinuxVersionRange_from_versions():
     assert version_range == expected
 
 
+def test_VersionRange_from_versions_with_empty_constraints():
+    sequence = []
+    expected = None
+    version_range = AlpineLinuxVersionRange.from_versions(sequence)
+    assert version_range == expected
+
+
 def test_apk_in_RANGE_CLASS_BY_SCHEMES():
     assert RANGE_CLASS_BY_SCHEMES["apk"] is AlpineLinuxVersionRange
 


### PR DESCRIPTION
resolves: https://github.com/aboutcode-org/univers/issues/192