### PR TITLE
fix: accept single-point Maven range like [5.0,5.0]

### DIFF
--- a/src/univers/maven.py
+++ b/src/univers/maven.py
@@ -77,14 +77,19 @@ class Restriction(object):
         _spec = spec[1:-1].strip()
         if "," in _spec:
             lower_bound, upper_bound = _spec.split(",")
-            if lower_bound and lower_bound == upper_bound:
-                raise RestrictionParseError("Range cannot have identical boundaries: %s" % spec)
 
             self.lower_bound = Version(lower_bound) if lower_bound else None
             self.upper_bound = Version(upper_bound) if upper_bound else None
 
-            if self.lower_bound and self.upper_bound and self.upper_bound < self.lower_bound:
-                raise RestrictionParseError("Range defies version ordering: %s" % spec)
+            if self.lower_bound and self.upper_bound:
+                if self.upper_bound < self.lower_bound:
+                    raise RestrictionParseError("Range defies version ordering: %s" % spec)
+                # Identical boundaries describe a single hard requirement such as
+                # [5.0,5.0] and are only valid when both bounds are inclusive.
+                if self.upper_bound == self.lower_bound and not (
+                    self.lower_bound_inclusive and self.upper_bound_inclusive
+                ):
+                    raise RestrictionParseError("Range cannot have identical boundaries: %s" % spec)
         else:
             # single version restriction
             if not self.lower_bound_inclusive or not self.upper_bound_inclusive:

--- a/tests/test_maven_version.py
+++ b/tests/test_maven_version.py
@@ -98,6 +98,17 @@ class TestRestriction(unittest.TestCase):
         assert "1.3.1" not in r
         assert "2.0" not in r
 
+    def test_identical_inclusive_boundaries(self):
+        r = Restriction("[5.0,5.0]")
+        assert str(r.lower_bound) == "5.0"
+        assert r.lower_bound_inclusive
+        assert str(r.upper_bound) == "5.0"
+        assert r.upper_bound_inclusive
+
+        assert "4.0" not in r
+        assert "5.0" in r
+        assert "5.1" not in r
+
     def test_exclusive_upper_bound(self):
         r = Restriction("[1.0,2.0)")
         assert str(r.lower_bound) == "1.0"

--- a/tests/test_maven_version_range.py
+++ b/tests/test_maven_version_range.py
@@ -36,6 +36,13 @@ def test_maven_version_range_from_native_for_pinned_version():
     )
 
 
+def test_maven_version_range_from_native_for_single_point_range():
+    version_range = MavenVersionRange.from_native("[5.0,5.0]")
+    assert version_range == MavenVersionRange(
+        constraints=(VersionConstraint(comparator="=", version=MavenVersion(string="5.0")),)
+    )
+
+
 def test_maven_version_range_from_native_for_illformed_version():
     try:
         MavenVersionRange.from_native("(1.0.0]")


### PR DESCRIPTION
`MavenVersionRange.from_native("[5.0,5.0]")` raises `RestrictionParseError`, but `[5.0,5.0]` is valid Maven: both ends inclusive just means exactly 5.0, same as `[5.0]`.

The parser rejected any equal-boundary range regardless of brackets. Maven only errors when a side is exclusive (`(5.0,5.0)`, `[5.0,5.0)`, `(5.0,5.0]`), since those are empty sets. I matched that, so `[5.0,5.0]` resolves to `vers:maven/5.0` and the exclusive forms still raise. Regression tests at the `Restriction` and `from_native` levels fail before, pass after.

I scoped this to the identical-boundaries case. The issue's other example is out-of-order overlap semantics that Maven doesn't pin down, so I used `Refs #142` (not `Fixes`) to keep the issue open, happy to take it separately if you can confirm the expected result.

Refs #142