### PR TITLE
Fix UnboundLocalError on single-clause npm version ranges

### DIFF
--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -13,6 +13,7 @@ from packaging.specifiers import InvalidSpecifier
 from packaging.specifiers import SpecifierSet
 from semantic_version.base import AllOf
 from semantic_version.base import AnyOf
+from semantic_version.base import Range
 
 from univers import gem
 from univers import maven
@@ -324,16 +325,21 @@ def get_npm_version_constraints_from_semver_npm_spec(string, cls):
     """
     spec = semantic_version.NpmSpec(string)
     clause = spec.clause.simplify()
-    if isinstance(clause, (AnyOf, AllOf)):
-        anyof_constraints = []
-        if isinstance(clause, AnyOf):
-            for allof_clause in clause.clauses:
-                anyof_constraints.extend(get_allof_constraints(cls, allof_clause))
-        elif isinstance(clause, AllOf):
-            alloc = get_allof_constraints(cls, clause)
-            anyof_constraints.extend(alloc)
-        else:
-            raise ValueError(f"Unknown clause type: {spec!r}")
+    anyof_constraints = []
+    if isinstance(clause, AnyOf):
+        for allof_clause in clause.clauses:
+            anyof_constraints.extend(get_allof_constraints(cls, allof_clause))
+    elif isinstance(clause, AllOf):
+        anyof_constraints.extend(get_allof_constraints(cls, clause))
+    elif isinstance(clause, Range):
+        # A simplified NpmSpec can collapse to a single Range clause, for
+        # example ">=1.x" or "*.x". Handle it here so we do not fall through
+        # with an unbound result.
+        comparator = cls.vers_by_native_comparators[clause.operator]
+        version = cls.version_class(str(clause.target))
+        anyof_constraints.append(VersionConstraint(comparator=comparator, version=version))
+    else:
+        raise InvalidVersionRange(f"Unknown clause type: {clause!r}")
     return anyof_constraints
 
 

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -18,6 +18,7 @@ from univers.version_range import DatetimeVersionRange
 from univers.version_range import IntdotVersionRange
 from univers.version_range import InvalidVersionRange
 from univers.version_range import MattermostVersionRange
+from univers.version_range import NpmVersionRange
 from univers.version_range import OpensslVersionRange
 from univers.version_range import PypiVersionRange
 from univers.version_range import VersionRange
@@ -293,6 +294,34 @@ def test_PypiVersionRange_raises_ivr_for_unsupported_and_invalid_ranges(range, w
             assert expected in str(ivre)
     else:
         assert expected == str(PypiVersionRange.from_native(range))
+
+
+@pytest.mark.parametrize(
+    "native, expected",
+    [
+        (">=1.x", "vers:npm/>=1.0.0"),
+        ("*.x", "vers:npm/>=0.0.0"),
+        (">1.x", "vers:npm/>=2.0.0"),
+        ("<=2.x", "vers:npm/<3.0.0"),
+    ],
+)
+def test_npm_range_from_native_single_clause(native, expected):
+    # These wildcard ranges simplify to a single node-semver clause and used to
+    # raise an UnboundLocalError instead of returning a VersionRange.
+    assert str(NpmVersionRange.from_native(native)) == expected
+
+
+@pytest.mark.parametrize(
+    "native, expected",
+    [
+        ("1.x", "vers:npm/>=1.0.0|<2.0.0"),
+        ("0.x", "vers:npm/>=0.0.0|<1.0.0"),
+        ("~1.x", "vers:npm/>=1.0.0|<2.0.0"),
+        ("1.2.x - 2.0.0", "vers:npm/>=1.2.0|<=2.0.0"),
+    ],
+)
+def test_npm_range_from_native_multi_clause_still_works(native, expected):
+    assert str(NpmVersionRange.from_native(native)) == expected
 
 
 def test_invert():


### PR DESCRIPTION
While parsing native node-semver ranges I hit an internal crash on some wildcard inputs.

`NpmVersionRange.from_native()` sends tokens like `>=1.x` and `*.x` through `get_npm_version_constraints_from_semver_npm_spec()`. That helper only assigns `anyof_constraints` inside the `isinstance(clause, (AnyOf, AllOf))` branch. When `NpmSpec(...).clause.simplify()` reduces to a single node-semver `Range` clause instead of an `AnyOf`/`AllOf`, execution falls straight through to the `return`, so a raw `UnboundLocalError` leaks out of the parser:

```
>>> from univers.version_range import NpmVersionRange
>>> NpmVersionRange.from_native(">=1.x")
UnboundLocalError: local variable 'anyof_constraints' referenced before assignment
```

`>=1.x`, `*.x`, `>1.x` and `<=2.x` all trip it, while ranges that expand to two bounds (`1.x`, `0.x`, `~1.x`, `1.2.x - 2.0.0`) were fine because they simplify to an `AllOf`.

The fix flattens the branch and adds an explicit case for the single `Range` clause, building one `VersionConstraint` from its operator and target the same way `get_allof_constraints` does per constraint. Any other unexpected clause type now raises `InvalidVersionRange` rather than the old (unreachable) `ValueError`. Multi-clause handling is unchanged.

After the change:

```
>>> str(NpmVersionRange.from_native(">=1.x"))
'vers:npm/>=1.0.0'
>>> str(NpmVersionRange.from_native("*.x"))
'vers:npm/>=0.0.0'
```

Added parametrized tests in `tests/test_version_range.py` covering the previously-crashing single-clause inputs and confirming the multi-clause ranges still produce the same output. The full `tests/test_version_range.py` suite passes.