### PR TITLE
Add "release" as an alias for the empty/release qualifier.

### DIFF
--- a/src/univers/maven.py
+++ b/src/univers/maven.py
@@ -33,6 +33,7 @@ QUALIFIERS = ["alpha", "beta", "milestone", "rc", "snapshot", "", "sp"]
 ALIASES = {
     "ga": "",
     "final": "",
+    "release": "",
     "cr": "rc",
 }
 


### PR DESCRIPTION
The Maven ComparableVersion spec defines "", "final", "ga", and "release" as equivalent, but univers is missing "release".

Fixes #188