### PR TITLE
Fix Version.__hash__ to be consistent with __eq__.

### DIFF
--- a/src/univers/maven.py
+++ b/src/univers/maven.py
@@ -419,7 +419,7 @@ class Version(object):
         return self.__cmp__(other) == 0
 
     def __hash__(self):
-        return hash(self._unparsed)
+        return hash(self._parsed)
 
     def __lt__(self, other):
         return self.__cmp__(other) < 0
@@ -492,6 +492,9 @@ class Version(object):
         return sublist
 
     def _normalize(self, l):
+        for i, item in enumerate(l):
+            if isinstance(item, list):
+                self._normalize(item)
         for item in l[::-1]:
             if not item:
                 l.pop()


### PR DESCRIPTION
Two bugs:
1. __hash__ uses _unparsed (raw string) but __eq__ uses _parsed, so "1" == "1.0" but hash differs.
2. _normalize doesn't recurse into sublists, so _parsed isn't fully canonical: "1-2-0" gets (1,(2,())) instead of (1,(2,)).

Fix _normalize to recurse into sublists first, making _parsed canonical, then use hash(_parsed) for __hash__.

Fixes #189