### PR TITLE
Reject empty strings in Maven, Nuget, Rubygems and Conan versions

### DIFF
--- a/src/univers/versions.py
+++ b/src/univers/versions.py
@@ -248,6 +248,8 @@ class SemverVersion(Version):
 
     @classmethod
     def is_valid(cls, string):
+        if not super().is_valid(string):
+            return False
         try:
             cls.build_value(string)
             return True
@@ -325,7 +327,7 @@ class RubygemsVersion(Version):
 
     @classmethod
     def is_valid(cls, string):
-        return gem.GemVersion.is_correct(string)
+        return super().is_valid(string) and gem.GemVersion.is_correct(string)
 
 
 class ArchLinuxVersion(Version):
@@ -375,6 +377,8 @@ class MavenVersion(Version):
 
     @classmethod
     def is_valid(cls, string):
+        if not super().is_valid(string):
+            return False
         try:
             cls.build_value(string)
             return True
@@ -392,6 +396,8 @@ class NugetVersion(Version):
 
     @classmethod
     def is_valid(cls, string):
+        if not super().is_valid(string):
+            return False
         try:
             cls.build_value(string)
             return True
@@ -664,6 +670,8 @@ class ConanVersion(Version):
 
     @classmethod
     def is_valid(cls, string):
+        if not super().is_valid(string):
+            return False
         try:
             cls.build_value(string)
             return True

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -253,3 +253,26 @@ def test_lexicographic_version():
     assert LexicographicVersion("Abc") < LexicographicVersion(None)
     assert LexicographicVersion("123") < LexicographicVersion("bbc")
     assert LexicographicVersion("2.3.4") > LexicographicVersion("1.2.3")
+
+
+def test_version_with_empty_string_is_invalid():
+    # https://github.com/aboutcode-org/univers/issues/204
+    # These schemes used to accept the empty string and then sort it as the
+    # minimum version (Maven, Rubygems), raise on comparison (Nuget), or
+    # both (Conan), silently corrupting downstream range logic.
+    import pytest
+
+    from univers.versions import ConanVersion
+    from univers.versions import InvalidVersion
+
+    for version_class in (
+        Version,
+        MavenVersion,
+        NugetVersion,
+        RubygemsVersion,
+        ConanVersion,
+        SemverVersion,
+        PypiVersion,
+    ):
+        with pytest.raises(InvalidVersion):
+            version_class("")


### PR DESCRIPTION
Fixes #204

`MavenVersion`, `NugetVersion`, `RubygemsVersion` -- and also `ConanVersion`, which the issue did not list but has the same hole (found by auditing every `Version` subclass with an empty string) -- accepted `""` because their `is_valid()` overrides only try to parse the value and the underlying parsers accept empty input. The base `Version.is_valid()` docstring already promises that the empty string is invalid; the overrides just never consulted it.

The fix makes each override check `super().is_valid(string)` first, so all four now raise `InvalidVersion("")` like `SemverVersion` and `PypiVersion` do, instead of the three different silent behaviors described in the issue (sorts-as-minimum, TypeError on comparison, or both). `DebianVersion` shares the same try/except body and gets the same guard for consistency, although its parser already rejected empty input.

Added a regression test covering the fixed classes plus `SemverVersion`/`PypiVersion` as canaries.

Test suite: `7272 passed`; the 2 failures in `test_semver_version` / `test_enhanced_semantic_version` (semver build-metadata ordering) are pre-existing on a clean checkout with the same environment and unrelated to this change.
