### PR TITLE
Do not allow creation of VersionRange with empty constraints

### DIFF
--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -67,6 +67,10 @@ class VersionRange:
     constraints = attr.ib(type=tuple, default=attr.Factory(tuple))
 
     def __attrs_post_init__(self, *args, **kwargs):
+        if not self.constraints:
+            raise ValueError(
+                f"{self.__class__.__name__} requires at least one VersionConstraint."
+            )
         constraints = tuple(sorted(self.constraints))
         # Notes: setattr is used because this is an immutable frozen instance.
         # See https://www.attrs.org/en/stable/init.html?#post-init

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@
 # Visit https://aboutcode.org and https://github.com/aboutcode-org/univers for support and download.
 
 from typing import NamedTuple
+from typing import Optional
 from typing import Union
 
 
@@ -14,13 +15,26 @@ class SchemaDrivenVersTest(NamedTuple):
     input: dict
     expected_output: Union[list, bool]
     description: str = ""
+    # name of the exception class expected to be raised while computing the
+    # result, for test cases whose input is invalid
+    expected_error: Optional[str] = None
 
     @classmethod
     def from_data(cls, data: dict):
         return cls(**data)
 
     def assert_result(self):
-        assert self.result == self.expected_output
+        if self.expected_error:
+            try:
+                self.result
+            except Exception as e:
+                assert type(e).__name__ == self.expected_error
+            else:
+                raise AssertionError(
+                    f"{self.expected_error} not raised for input: {self.input!r}"
+                )
+        else:
+            assert self.result == self.expected_output
 
     @property
     def result(self):

--- a/tests/data/schema/range/conan_range_from_native.json
+++ b/tests/data/schema/range/conan_range_from_native.json
@@ -1137,7 +1137,8 @@
       "native_range": "",
       "scheme": "conan"
     },
-    "expected_output": "vers:conan/"
+    "expected_output": null,
+    "expected_error": "ValueError"
   },
   {
     "description": "Construct VERS range from native conan range.",
@@ -1437,7 +1438,8 @@
       "native_range": "",
       "scheme": "conan"
     },
-    "expected_output": "vers:conan/"
+    "expected_output": null,
+    "expected_error": "ValueError"
   },
   {
     "description": "Construct VERS range from native conan range.",

--- a/tests/data/schema/range/gitlab/conan_gitlab_range_from_native.json
+++ b/tests/data/schema/range/gitlab/conan_gitlab_range_from_native.json
@@ -1137,7 +1137,8 @@
       "native_range": "",
       "scheme": "conan"
     },
-    "expected_output": "vers:conan/"
+    "expected_output": null,
+    "expected_error": "ValueError"
   },
   {
     "description": "Construct VERS range from GitLab native conan range.",
@@ -1437,7 +1438,8 @@
       "native_range": "",
       "scheme": "conan"
     },
-    "expected_output": "vers:conan/"
+    "expected_output": null,
+    "expected_error": "ValueError"
   },
   {
     "description": "Construct VERS range from GitLab native conan range.",

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -458,3 +458,13 @@ def test_version_range_lexicographic():
     assert LexicographicVersion(-123) in VersionRange.from_string("vers:lexicographic/<~")
     assert LexicographicVersion(None) in VersionRange.from_string("vers:lexicographic/*")
     assert LexicographicVersion("ABC") in VersionRange.from_string("vers:lexicographic/>abc|<=None")
+
+
+def test_version_range_with_empty_constraints_is_invalid():
+    # https://github.com/aboutcode-org/univers/issues/203
+    with pytest.raises(ValueError):
+        VersionRange(constraints=[])
+    with pytest.raises(ValueError):
+        RANGE_CLASS_BY_SCHEMES["apache"](constraints=[])
+    with pytest.raises(ValueError):
+        VersionRange.from_string("vers:apache/")


### PR DESCRIPTION
Fixes #203

`VersionRange` subclasses could be constructed directly with an empty constraints sequence and then serialized to an invalid vers string such as `vers:apache/` -- `from_string()` already rejects those strings, so direct construction was the only way to produce them (as in the issue's reproducer).

`__attrs_post_init__` now raises `ValueError` when `constraints` is empty.

Two consequences handled in this PR:

- Four Conan `from_native` data-driven test cases expected the empty native range `""` to produce `vers:conan/`, i.e. the test data encoded the invalid output. Those cases now expect a `ValueError`.
- The schema-driven test harness (`SchemaDrivenVersTest`) had no way to express an expected failure, so it gains an optional `expected_error` field naming the exception class; cases without it behave exactly as before.

Also added a direct regression test constructing `VersionRange(constraints=[])`, a subclass with empty constraints, and `from_string("vers:apache/")`.

Test suite: `7271 passed`; the 2 failures in `test_semver_version` / `test_enhanced_semantic_version` are pre-existing on a clean checkout with the same environment (also noted in #209) and unrelated to this change.
