### PR TITLE
Implement __le__ and __ge__ for GentooVersion

### DIFF
--- a/src/univers/versions.py
+++ b/src/univers/versions.py
@@ -429,6 +429,16 @@ class GentooVersion(Version):
             return NotImplemented
         return gentoo.vercmp(self.value, other.value) == 1
 
+    def __le__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return gentoo.vercmp(self.value, other.value) <= 0
+
+    def __ge__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return gentoo.vercmp(self.value, other.value) >= 0
+
 
 class AlpineLinuxVersion(GentooVersion):
     @classmethod

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -170,6 +170,14 @@ def test_rpm_version():
 def test_gentoo_version():
     assert GentooVersion("1.2.3") == GentooVersion("1.2.3")
     assert GentooVersion("1.2.3") != GentooVersion("1.2.4")
+    assert GentooVersion("1.2.0-r0") < GentooVersion("1.10.0-r0")
+    assert GentooVersion("1.2.0-r0") <= GentooVersion("1.10.0-r0")
+    assert GentooVersion("1.10.0-r0") > GentooVersion("1.2.0-r0")
+    assert GentooVersion("1.10.0-r0") >= GentooVersion("1.2.0-r0")
+    assert not GentooVersion("1.10.0-r0") <= GentooVersion("1.2.0-r0")
+    assert not GentooVersion("1.2.0-r0") >= GentooVersion("1.10.0-r0")
+    assert GentooVersion("1.2.0-r0") <= GentooVersion("1.2.0-r0")
+    assert GentooVersion("1.2.0-r0") >= GentooVersion("1.2.0-r0")
     assert GentooVersion.is_valid("1.2.3")
     assert not GentooVersion.is_valid("1.2.3a-1-a")
 
@@ -181,6 +189,10 @@ def test_alpine_linux_version():
     assert AlpineLinuxVersion("1.2.3-r1") < AlpineLinuxVersion("1.2.3-r2")
     assert AlpineLinuxVersion("1.2.3-r1") >= AlpineLinuxVersion("1.2.3-r1")
     assert AlpineLinuxVersion("1.2.3-r1") <= AlpineLinuxVersion("1.2.3-r1")
+    assert AlpineLinuxVersion("1.2.0-r0") <= AlpineLinuxVersion("1.10.0-r0")
+    assert AlpineLinuxVersion("1.10.0-r0") >= AlpineLinuxVersion("1.2.0-r0")
+    assert not AlpineLinuxVersion("1.10.0-r0") <= AlpineLinuxVersion("1.2.0-r0")
+    assert not AlpineLinuxVersion("1.2.0-r0") >= AlpineLinuxVersion("1.10.0-r0")
     assert AlpineLinuxVersion.is_valid("1.2.3-r1")
     assert not AlpineLinuxVersion.is_valid("007")
 


### PR DESCRIPTION
Fixes #172

GentooVersion defines `__eq__`, `__lt__` and `__gt__`, but not `__le__` and `__ge__`. Those two fall back to the ones generated by `@attr.s(order=True)` on the Version base class, which compare the raw version strings. That gives the wrong answer when string order and version order do not agree.

```python
>>> from univers.versions import GentooVersion
>>> GentooVersion("1.2.0-r0") <= GentooVersion("1.10.0-r0")
False
>>> GentooVersion("1.10.0-r0") >= GentooVersion("1.2.0-r0")
False
```

AlpineLinuxVersion extends GentooVersion, so it had the same problem.

This adds `__le__` and `__ge__` that use `gentoo.vercmp`, the same way ArchLinuxVersion already does, plus tests for both classes.
